### PR TITLE
パスワードリセット実装

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -39,6 +39,7 @@ gem "bootsnap", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.2.3)
     crass (1.0.6)
     daemons (1.4.1)
@@ -151,6 +153,12 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.5.6)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
     puma (5.6.8)
@@ -240,6 +248,7 @@ DEPENDENCIES
   jsonapi-serializer
   mailcatcher
   pg (~> 1.1)
+  pry-byebug
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.8, >= 7.0.8.3)

--- a/backend/app/controllers/users/passwords_controller.rb
+++ b/backend/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,24 @@
+class Users::PasswordsController < Devise::PasswordsController
+  respond_to :json
+
+  private
+
+  def respond_with(resource, _opts = {})
+    send_reset_mail_success && return unless resource.present?
+    reset_password_success && return if resource.persisted?
+
+    reset_password_failed
+  end
+
+  def send_reset_mail_success
+    render json: { message: 'Send Reset Mail sucessfully.' }
+  end
+
+  def reset_password_success
+    render json: { message: 'Password Reset sucessfully.' }
+  end
+
+  def reset_password_failed
+    render json: { message: "Something went wrong." }
+  end
+end

--- a/backend/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/backend/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,3 @@
+<p>パスワード再設定メール</p>
+<p>以下のページよりパスワードの再設定を行なってください</p>
+<p><%= link_to 'Change my password', edit_user_password_url(@resource, reset_password_token: @token) %></p>

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -23,5 +23,8 @@ module Backend
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.session_store :cookie_store, key: '_interslice_session'
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use config.session_store, config.session_options
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,8 +7,10 @@ Rails.application.routes.draw do
   controllers: {
     sessions: 'users/sessions',
     registrations: 'users/registrations',
-    confirmations: 'users/confirmations'
+    confirmations: 'users/confirmations',
+    passwords: 'users/passwords'
   }
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
# 概要

パスワードリセットのバックエンド部分を実装しました

1.パスワドリセット(post)`http://localhost:3000/password`をたたくとリセットメールが送信さます。

2.パスワドリセット(put)`http://localhost:3000/password`をたたくと新しいパスワードに変更することができる

### パスワードリセット確認手順

1.user を作成します。console を使用して作成。

```
user = User.create!(
  email: "user@example.com",
  password: "securepassword",
  password_confirmation: "securepassword",
  name "'takashi',
  &:confirm)
```

2.リセットメール送信

・URL：http://localhost:3000/password
・Method：POST
・Body：

```
{
  "user": {
    "email": "user@example.com"
  }
}
```

3.パスワード変更
・URL：http://localhost:3000/password
・Method：PUT
・Body：

```
{
  "user": {
    "reset_password_token": "YGTF1Z3xVKFLbwYLU3Qt",
    "password": "password",
    "password_confirmation": "password"
  }
}
```
レスポンス
```
{
    "message": "Password Reset sucessfully."
}
```

reset_password_toke は、メールから取得。
<img width="1139" alt="スクリーンショット 2024-05-31 7 35 36" src="https://github.com/Kazuya-Sakashita/ChatWave/assets/64903209/2837ac7d-56af-45ee-91be-1c64ef1042db">


4.新しいパスワードでログインができるか確認
