### PR TITLE
ログインページ実装

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import SignupPage from "./components/SignupPage";
+import LoginPage from "./components/LoginPage";
 
 const App: React.FC = () => {
   return (
     <Router>
       <Routes>
         <Route path="/signup" element={<SignupPage />} />
+        <Route path="/login" element={<LoginPage />} />
         {/* 他のルート */}
       </Routes>
     </Router>

--- a/frontend/app/src/components/LoginPage.module.css
+++ b/frontend/app/src/components/LoginPage.module.css
@@ -1,0 +1,60 @@
+.form-container {
+  max-width: 400px;
+  margin: 50px auto;
+  padding: 30px;
+  border: 1px solid #d0e1f9;
+  border-radius: 8px;
+  background-color: #f0f4fb;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.form-container div {
+  margin-bottom: 20px;
+}
+
+.form-container label {
+  display: block;
+  margin-bottom: 8px;
+  color: #333;
+  font-weight: bold;
+}
+
+.form-container input {
+  width: 100%;
+  padding: 12px;
+  box-sizing: border-box;
+  border: 1px solid #d0e1f9;
+  border-radius: 4px;
+  background-color: #fff;
+}
+
+.form-container input:focus {
+  border-color: #80bdff;
+  outline: none;
+  box-shadow: 0 0 5px rgba(128, 189, 255, 0.5);
+}
+
+.form-container button {
+  width: 100%;
+  padding: 12px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.form-container button:hover {
+  background-color: #0056b3;
+}
+
+h1 {
+  text-align: center;
+  color: #333;
+}
+
+p {
+  text-align: center;
+}

--- a/frontend/app/src/components/LoginPage.tsx
+++ b/frontend/app/src/components/LoginPage.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import axios from "../api/axiosConfig";
+import styles from "./LoginPage.module.css";
+
+const LoginPage: React.FC = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError("");
+
+    try {
+      await axios.post("/login", {
+        user: {
+          email,
+          password,
+        },
+      });
+      alert("User logged in successfully");
+    } catch (err) {
+      setError("Failed to login");
+    }
+  };
+
+  return (
+    <div className={styles["form-container"]}>
+      <h1>Login</h1>
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Email:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label>Password:</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <button type="submit">Login</button>
+      </form>
+    </div>
+  );
+};
+
+export default LoginPage;


### PR DESCRIPTION
既存のユーザーがアカウントにログインするためのログイン画面を実装します。
バックエンドのAPIと連携して、ログイン情報を送信します。


1. ログイン画面（http://localhost:8000/login）に遷移
2. フォームに必要項目入力（メールアドレス、パスワード）
3. 「Sign Up」ボタンをクリック
<img width="1093" alt="スクリーンショット 2024-05-31 22 45 37" src="https://github.com/Kazuya-Sakashita/ChatWave/assets/64903209/0421d704-2afb-4675-952c-2c1fee6d9c1f">

# 期待する動作
「Login」」ボタンをクリック後、alert("User logged in successfully")を表示
<img width="1089" alt="スクリーンショット 2024-05-31 22 45 27" src="https://github.com/Kazuya-Sakashita/ChatWave/assets/64903209/dcf10bb6-bdf1-4a54-9648-a4a55f320d84">


# 動作環境

Closes #20