### PR TITLE
サインアップ後にメール確認を促す画面実装

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import SignupPage from "./components/SignupPage";
 import LoginPage from "./components/LoginPage";
+import EmailConfirmationPage from "./components/EmailConfirmationPage";
 
 const App: React.FC = () => {
   return (
@@ -9,6 +10,7 @@ const App: React.FC = () => {
       <Routes>
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/confirmation" element={<EmailConfirmationPage />} />
         {/* 他のルート */}
       </Routes>
     </Router>

--- a/frontend/app/src/components/EmailConfirmationPage.css
+++ b/frontend/app/src/components/EmailConfirmationPage.css
@@ -1,0 +1,25 @@
+/* EmailConfirmationPage.css */
+.confirmation-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background-color: #f7f9fc;
+  padding: 20px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.confirmation-title {
+  font-size: 2em;
+  color: #333;
+  margin-bottom: 20px;
+}
+
+.confirmation-message {
+  font-size: 1.2em;
+  color: #555;
+  text-align: center;
+  max-width: 600px;
+  line-height: 1.5;
+}

--- a/frontend/app/src/components/EmailConfirmationPage.tsx
+++ b/frontend/app/src/components/EmailConfirmationPage.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import "./EmailConfirmationPage.css"; // 外部CSSファイルを読み込む
+
+const EmailConfirmationPage: React.FC = () => {
+  return (
+    <div className="confirmation-container">
+      <h1 className="confirmation-title">メールを確認してください</h1>
+      <p className="confirmation-message">
+        ご登録ありがとうございます！メールを確認し、アカウントを有効化するための確認リンクをクリックしてください。
+      </p>
+    </div>
+  );
+};
+
+export default EmailConfirmationPage;

--- a/frontend/app/src/components/SignupPage.tsx
+++ b/frontend/app/src/components/SignupPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import axios from "../api/axiosConfig";
+import { useNavigate } from "react-router-dom";
 import styles from "./SignupPage.module.css";
 
 const SignupPage: React.FC = () => {
@@ -8,6 +9,7 @@ const SignupPage: React.FC = () => {
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
   const [error, setError] = useState("");
+  const navigate = useNavigate(); // useNavigate フックを使用して navigate 関数を取得
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -27,7 +29,7 @@ const SignupPage: React.FC = () => {
           password_confirmation: passwordConfirmation,
         },
       });
-      alert("User registered successfully");
+      navigate("/confirmation"); // サインアップ後にメール確認画面にリダイレクト
     } catch (err) {
       setError("Failed to register");
     }


### PR DESCRIPTION
# 概要

サインアップ後にメール確認を促す画面のデザインと実装しました
メール確認を促すメッセージ表示するようにしています。

# 期待する動作

サインアップ後にメール確認を促す画面へ遷移
画面に下記文面を表示する

```
メールを確認してください

ご登録ありがとうございます！メールを確認し、アカウントを有効化するための確認リンクをクリックしてください。
```

1. ログイン画面（http://localhost:8000/signup）に遷移
2. フォームに必要項目入力（Name,Email,Password,Confirm Password）
3. 「Sign Up」ボタンをクリック
4.  案内画面(http://localhost:8000/confirmation)に遷移


# 動作環境

Closes #23
