### PR TITLE
パスワードリセット画面の実装 #22

### DIFF
--- a/backend/app/controllers/users/passwords_controller.rb
+++ b/backend/app/controllers/users/passwords_controller.rb
@@ -1,24 +1,70 @@
 class Users::PasswordsController < Devise::PasswordsController
   respond_to :json
 
+  def create
+    self.resource = resource_class.send_reset_password_instructions(resource_params)
+    yield resource if block_given?
+
+    if successfully_sent?(resource)
+      Rails.logger.info "Reset password instructions sent to #{resource.email}"
+      send_reset_mail_success
+    else
+      Rails.logger.error "Failed to send reset password instructions to #{resource.email}: #{resource.errors.full_messages.join(", ")}"
+      send_reset_mail_failed(resource)
+    end
+  end
+
+  def update
+    logger.info "Received parameters: #{params.inspect}"
+    user_params = params.require(:user).permit(:reset_password_token, :password, :password_confirmation)
+    logger.info "Sanitized parameters: #{user_params.inspect}"
+
+    user = User.find_by(reset_password_token: Devise.token_generator.digest(User, :reset_password_token, user_params[:reset_password_token]))
+    logger.info "User found: #{user.inspect}"
+
+    if user.nil?
+      logger.error "Failed to reset password: Reset password token is invalid"
+      render json: { message: 'パスワードのリセットに失敗しました。', errors: ['Reset password token is invalid'] }, status: :unprocessable_entity
+      return
+    end
+
+    self.resource = resource_class.reset_password_by_token(user_params)
+    if resource.errors.empty?
+      resource.unlock_access! if unlockable?(resource)
+      reset_password_success
+    else
+      logger.error "Failed to reset password: #{resource.errors.full_messages.join(", ")}"
+      reset_password_failed(resource)
+    end
+  end
+
   private
 
   def respond_with(resource, _opts = {})
-    send_reset_mail_success && return unless resource.present?
-    reset_password_success && return if resource.persisted?
-
-    reset_password_failed
+    if resource.errors.empty?
+      reset_password_success
+    else
+      reset_password_failed(resource)
+    end
   end
 
   def send_reset_mail_success
-    render json: { message: 'Send Reset Mail sucessfully.' }
+    render json: { message: 'パスワードリセットメールを送信しました。' }
+  end
+
+  def send_reset_mail_failed(resource)
+    render json: { message: 'メールの送信に失敗しました。', errors: resource.errors.full_messages }
   end
 
   def reset_password_success
-    render json: { message: 'Password Reset sucessfully.' }
+    render json: { message: 'パスワードが正常にリセットされました。' }
   end
 
-  def reset_password_failed
-    render json: { message: "Something went wrong." }
+  def reset_password_failed(resource)
+    render json: { message: 'パスワードのリセットに失敗しました。', errors: resource.errors.full_messages }
+  end
+
+  def resource_params
+    params.require(:user).permit(:email, :reset_password_token, :password, :password_confirmation)
   end
 end

--- a/backend/app/controllers/users/passwords_controller.rb
+++ b/backend/app/controllers/users/passwords_controller.rb
@@ -2,29 +2,36 @@ class Users::PasswordsController < Devise::PasswordsController
   respond_to :json
 
   def create
+    user = User.find_by(email: resource_params[:email])
+    if user && user.confirmed_at.nil?
+      log_error("Failed to send reset password instructions to #{user.email}: Email not confirmed")
+      unconfirmed_email
+      return
+    end
+
     self.resource = resource_class.send_reset_password_instructions(resource_params)
     yield resource if block_given?
 
     if successfully_sent?(resource)
-      Rails.logger.info "Reset password instructions sent to #{resource.email}"
+      log_info("Reset password instructions sent to #{resource.email}")
       send_reset_mail_success
     else
-      Rails.logger.error "Failed to send reset password instructions to #{resource.email}: #{resource.errors.full_messages.join(", ")}"
+      log_error("Failed to send reset password instructions to #{resource.email}: #{resource.errors.full_messages.join(", ")}")
       send_reset_mail_failed(resource)
     end
   end
 
   def update
-    logger.info "Received parameters: #{params.inspect}"
+    log_info("Received parameters: #{params.inspect}")
     user_params = params.require(:user).permit(:reset_password_token, :password, :password_confirmation)
-    logger.info "Sanitized parameters: #{user_params.inspect}"
+    log_info("Sanitized parameters: #{user_params.inspect}")
 
     user = User.find_by(reset_password_token: Devise.token_generator.digest(User, :reset_password_token, user_params[:reset_password_token]))
-    logger.info "User found: #{user.inspect}"
+    log_info("User found: #{user.inspect}")
 
     if user.nil?
-      logger.error "Failed to reset password: Reset password token is invalid"
-      render json: { message: 'パスワードのリセットに失敗しました。', errors: ['Reset password token is invalid'] }, status: :unprocessable_entity
+      log_error("Failed to reset password: Reset password token is invalid")
+      reset_password_token_invalid
       return
     end
 
@@ -33,7 +40,7 @@ class Users::PasswordsController < Devise::PasswordsController
       resource.unlock_access! if unlockable?(resource)
       reset_password_success
     else
-      logger.error "Failed to reset password: #{resource.errors.full_messages.join(", ")}"
+      log_error("Failed to reset password: #{resource.errors.full_messages.join(", ")}")
       reset_password_failed(resource)
     end
   end
@@ -64,7 +71,23 @@ class Users::PasswordsController < Devise::PasswordsController
     render json: { message: 'パスワードのリセットに失敗しました。', errors: resource.errors.full_messages }
   end
 
+  def reset_password_token_invalid
+    render json: { message: 'パスワードのリセットに失敗しました。', errors: ['Reset password token is invalid'] }, status: :unprocessable_entity
+  end
+
+  def unconfirmed_email
+    render json: { message: 'メールアドレスが確認されていません。' }, status: :unprocessable_entity
+  end
+
   def resource_params
     params.require(:user).permit(:email, :reset_password_token, :password, :password_confirmation)
+  end
+
+  def log_info(message)
+    Rails.logger.info(message)
+  end
+
+  def log_error(message)
+    Rails.logger.error(message)
   end
 end

--- a/backend/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/backend/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,3 +1,5 @@
 <p>パスワード再設定メール</p>
 <p>以下のページよりパスワードの再設定を行なってください</p>
-<p><%= link_to 'Change my password', edit_user_password_url(@resource, reset_password_token: @token) %></p>
+<p>
+  <%= link_to 'パスワードをリセット', "http://localhost:8000/password/edit/#{@token}" %>
+</p>

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -8,6 +8,8 @@ import Header from "./components/Header";
 import HomePage from "./components/HomePage";
 import RequireAuth from "./components/RequireAuth";
 import EmailConfirmationPage from "./components/EmailConfirmationPage";
+import PasswordResetRequestPage from "./components/PasswordResetRequestPage";
+import PasswordResetPage from "./components/PasswordResetPage";
 
 const App: React.FC = () => {
   return (
@@ -26,6 +28,14 @@ const App: React.FC = () => {
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/confirmation" element={<EmailConfirmationPage />} />
+          <Route
+            path="/password/reset"
+            element={<PasswordResetRequestPage />}
+          />
+          <Route
+            path="/password/edit/:reset_password_token"
+            element={<PasswordResetPage />}
+          />
           {/* 他のルート */}
         </Routes>
       </Router>

--- a/frontend/app/src/components/FormStyles.module.css
+++ b/frontend/app/src/components/FormStyles.module.css
@@ -1,62 +1,46 @@
 .form-container {
   max-width: 400px;
-  margin: 50px auto;
-  padding: 30px;
-  border: 1px solid #d0e1f9;
-  border-radius: 8px;
-  background-color: #f0f4fb;
+  margin: 0 auto;
+  padding: 20px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
-.form-container div {
+.form-container h1 {
+  text-align: center;
   margin-bottom: 20px;
+}
+
+.form-container div {
+  margin-bottom: 15px;
 }
 
 .form-container label {
   display: block;
-  margin-bottom: 8px;
-  color: #333;
-  font-weight: bold;
+  margin-bottom: 5px;
 }
 
 .form-container input {
   width: 100%;
-  padding: 12px;
+  padding: 8px;
   box-sizing: border-box;
-  border: 1px solid #d0e1f9;
+  border: 1px solid #ccc;
   border-radius: 4px;
-  background-color: #fff;
-}
-
-.form-container input:focus {
-  border-color: #80bdff;
-  outline: none;
-  box-shadow: 0 0 5px rgba(128, 189, 255, 0.5);
 }
 
 .form-container button {
   width: 100%;
-  padding: 12px;
+  padding: 10px;
   background-color: #007bff;
   color: white;
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 16px;
-  font-weight: bold;
 }
 
 .form-container button:hover {
   background-color: #0056b3;
-}
-
-h1 {
-  text-align: center;
-  color: #333;
-}
-
-p {
-  text-align: center;
 }
 
 .reset-link {

--- a/frontend/app/src/components/FormStyles.module.css
+++ b/frontend/app/src/components/FormStyles.module.css
@@ -1,46 +1,68 @@
 .form-container {
   max-width: 400px;
-  margin: 0 auto;
-  padding: 20px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  margin: 50px auto;
+  padding: 30px;
+  border: 1px solid #d0e1f9;
+  border-radius: 8px;
+  background-color: #f0f4fb;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
-.form-container h1 {
-  text-align: center;
-  margin-bottom: 20px;
-}
-
 .form-container div {
-  margin-bottom: 15px;
+  margin-bottom: 20px;
 }
 
 .form-container label {
   display: block;
-  margin-bottom: 5px;
+  margin-bottom: 8px;
+  color: #333;
+  font-weight: bold;
 }
 
 .form-container input {
   width: 100%;
-  padding: 8px;
+  padding: 12px;
   box-sizing: border-box;
-  border: 1px solid #ccc;
+  border: 1px solid #d0e1f9;
   border-radius: 4px;
+  background-color: #fff;
+}
+
+.form-container input:focus {
+  border-color: #80bdff;
+  outline: none;
+  box-shadow: 0 0 5px rgba(128, 189, 255, 0.5);
 }
 
 .form-container button {
   width: 100%;
-  padding: 10px;
+  padding: 12px;
   background-color: #007bff;
   color: white;
   border: none;
   border-radius: 4px;
   cursor: pointer;
+  font-size: 16px;
+  font-weight: bold;
 }
 
 .form-container button:hover {
   background-color: #0056b3;
+}
+
+h1 {
+  text-align: center;
+  color: #333;
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 20px;
+  white-space: nowrap; /* タイトルが折り返されないようにする */
+}
+
+p {
+  text-align: center;
+  font-size: 14px;
+  color: #333;
 }
 
 .reset-link {
@@ -55,4 +77,16 @@
 
 .reset-link a:hover {
   text-decoration: underline;
+}
+
+.error-message {
+  color: red;
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.success-message {
+  color: green;
+  text-align: center;
+  margin-bottom: 10px;
 }

--- a/frontend/app/src/components/LoginPage.tsx
+++ b/frontend/app/src/components/LoginPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import styles from "./LoginPage.module.css";
 import { performLogin } from "../store/authSlice";
 import { AppDispatch } from "../store";
@@ -73,6 +73,9 @@ const LoginPage: React.FC = () => {
         </div>
         <button type="submit">Login</button>
       </form>
+      <div className={styles["reset-link"]}>
+        <Link to="/password/reset">Forgot your password?</Link>
+      </div>
     </div>
   );
 };

--- a/frontend/app/src/components/PasswordResetPage.tsx
+++ b/frontend/app/src/components/PasswordResetPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import axios from "../api/axiosConfig";
 import ErrorMessage from "../components/ErrorMessage";
 import styles from "./FormStyles.module.css";
-import { PasswordResetPageState } from "../types/componentTypes";
+import { PasswordResetPageState } from "../types/componentTypes"; // PasswordResetPageState型をインポート
 
 const PasswordResetPage: React.FC = () => {
   const { reset_password_token } = useParams<{
@@ -24,24 +24,24 @@ const PasswordResetPage: React.FC = () => {
     setError(null);
 
     if (password !== passwordConfirmation) {
-      setError("Passwords do not match");
+      setError("パスワードのリセットに失敗しました");
       return;
     }
 
-    const requestData = {
-      user: {
-        reset_password_token,
-        password,
-        password_confirmation: passwordConfirmation,
-      },
-    };
-
-    console.log("Sending data:", requestData); // コンソールに送信データを表示
-
     try {
-      await axios.put("/password", requestData);
-      setMessage("パスワードが正常にリセットされました");
-      navigate("/login");
+      await axios.put("/password", {
+        user: {
+          reset_password_token,
+          password,
+          password_confirmation: passwordConfirmation,
+        },
+      });
+      setMessage(
+        "パスワードが正常にリセットされました。ログインページにリダイレクトします..."
+      );
+      setTimeout(() => {
+        navigate("/login");
+      }, 3000); // 3秒後にログインページにリダイレクト
     } catch (err) {
       setError("パスワードのリセットに失敗しました");
       console.error(err);
@@ -52,7 +52,7 @@ const PasswordResetPage: React.FC = () => {
     <div className={styles["form-container"]}>
       <h1>パスワードリセット</h1>
       <ErrorMessage message={error} />
-      {message && <p style={{ color: "green" }}>{message}</p>}
+      {message && <p className={styles["success-message"]}>{message}</p>}
       <form onSubmit={handleSubmit}>
         <div>
           <label>新しいパスワード:</label>

--- a/frontend/app/src/components/PasswordResetPage.tsx
+++ b/frontend/app/src/components/PasswordResetPage.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import axios from "../api/axiosConfig";
+import ErrorMessage from "../components/ErrorMessage";
+import styles from "./FormStyles.module.css";
+import { PasswordResetPageState } from "../types/componentTypes";
+
+const PasswordResetPage: React.FC = () => {
+  const { reset_password_token } = useParams<{
+    reset_password_token: string;
+  }>();
+  const [password, setPassword] =
+    useState<PasswordResetPageState["password"]>("");
+  const [passwordConfirmation, setPasswordConfirmation] =
+    useState<PasswordResetPageState["passwordConfirmation"]>("");
+  const [message, setMessage] =
+    useState<PasswordResetPageState["message"]>(null);
+  const [error, setError] = useState<PasswordResetPageState["error"]>(null);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setMessage(null);
+    setError(null);
+
+    if (password !== passwordConfirmation) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    const requestData = {
+      user: {
+        reset_password_token,
+        password,
+        password_confirmation: passwordConfirmation,
+      },
+    };
+
+    console.log("Sending data:", requestData); // コンソールに送信データを表示
+
+    try {
+      await axios.put("/password", requestData);
+      setMessage("パスワードが正常にリセットされました");
+      navigate("/login");
+    } catch (err) {
+      setError("パスワードのリセットに失敗しました");
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className={styles["form-container"]}>
+      <h1>パスワードリセット</h1>
+      <ErrorMessage message={error} />
+      {message && <p style={{ color: "green" }}>{message}</p>}
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>新しいパスワード:</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label>パスワードを確認:</label>
+          <input
+            type="password"
+            value={passwordConfirmation}
+            onChange={(e) => setPasswordConfirmation(e.target.value)}
+            required
+          />
+        </div>
+        <button type="submit">パスワードをリセット</button>
+      </form>
+    </div>
+  );
+};
+
+export default PasswordResetPage;

--- a/frontend/app/src/components/PasswordResetRequestPage.tsx
+++ b/frontend/app/src/components/PasswordResetRequestPage.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import axios from "../api/axiosConfig";
+import ErrorMessage from "../components/ErrorMessage";
+import styles from "./FormStyles.module.css";
+
+const PasswordResetRequestPage: React.FC = () => {
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setMessage(null);
+    setError(null);
+
+    try {
+      await axios.post("/password", { user: { email } });
+      setMessage("パスワードリセットリンクがメールアドレスに送信されました");
+    } catch (err) {
+      setError("パスワードリセットリンクの送信に失敗しました");
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className={styles["form-container"]}>
+      <h1>パスワードリセットのリクエスト</h1>
+      <ErrorMessage message={error} />
+      {message && <p style={{ color: "green" }}>{message}</p>}
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>メールアドレス:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <button type="submit">リセットリンクを送信</button>
+      </form>
+    </div>
+  );
+};
+
+export default PasswordResetRequestPage;

--- a/frontend/app/src/components/PasswordResetRequestPage.tsx
+++ b/frontend/app/src/components/PasswordResetRequestPage.tsx
@@ -25,8 +25,8 @@ const PasswordResetRequestPage: React.FC = () => {
   return (
     <div className={styles["form-container"]}>
       <h1>パスワードリセットのリクエスト</h1>
-      <ErrorMessage message={error} />
-      {message && <p style={{ color: "green" }}>{message}</p>}
+      {error && <p className={styles["error-message"]}>{error}</p>}
+      {message && <p className={styles["success-message"]}>{message}</p>}
       <form onSubmit={handleSubmit}>
         <div>
           <label>メールアドレス:</label>
@@ -39,6 +39,9 @@ const PasswordResetRequestPage: React.FC = () => {
         </div>
         <button type="submit">リセットリンクを送信</button>
       </form>
+      <div className={styles["reset-link"]}>
+        <a href="/login">ログインページに戻る</a>
+      </div>
     </div>
   );
 };

--- a/frontend/app/src/types/componentTypes.ts
+++ b/frontend/app/src/types/componentTypes.ts
@@ -23,3 +23,18 @@ export interface SignupPageState {
 export interface LogoutResponse {
   // 必要に応じてログアウトのレスポンスの型を定義
 }
+
+// PasswordResetRequestPageコンポーネントのローカルステートの型を定義
+export interface PasswordResetRequestPageState {
+  email: string;
+  message: string | null;
+  error: string | null;
+}
+
+// PasswordResetPageコンポーネントのローカルステートの型を定義
+export interface PasswordResetPageState {
+  password: string;
+  passwordConfirmation: string;
+  message: string | null;
+  error: string | null;
+}


### PR DESCRIPTION
# 概要 パスワードリセット画面の実装

ユーザーがパスワードをリセットするための画面を実装します。
バックエンドの API と連携して、パスワードリセットの要求と新しいパスワードの設定を行います。

- パスワードリセットフォームのデザイン
- フォーム入力のバリデーション
- パスワードリセット API の呼び出し
- リセット成功・失敗時のメッセージ表示

# 期待する動作

1. ログイン画面のログインボタン下よりパスワードリセットに遷移
2. メールアドレスを入力後、リセットリンク送信を押す
3. `http://localhost:1080/` MailCatcher にメールがあるので、そこからパスワードリセットリンクへ遷移
4. パスワードリセット画面に遷移するので、新しいパスワード、パスワード確認フォームに入力しパスワードリセットボタンを押す
5. 正常にリセットできた場合は、3 秒後にログイン画面にリダイレクト。


## 実装できないこと
サインアップでメール認証せず、パスワードリセットをした際にバグってしまっています。ここは対策が必要かと思います。

Closes #22