### PR TITLE
メッセージ通知の設定オプションUIの実装 #52

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -27,7 +27,7 @@ users.each do |user|
   profile = user.build_profile(
     full_name: Faker::Name.name,
     birth_date: Faker::Date.birthday(min_age: 18, max_age: 65),
-    gender: ['男', '女'].sample,
+    gender: ['male', 'female', 'other'].sample,
     phone_number: Faker::Number.leading_zero_number(digits: 11),  # 11桁の日本の電話番号
     postal_code: Faker::Number.number(digits: 7),                 # 7桁の日本の郵便番号
     address: Faker::Address.full_address

--- a/frontend/app/src/components/ProfilePage.tsx
+++ b/frontend/app/src/components/ProfilePage.tsx
@@ -88,6 +88,21 @@ const ProfilePage: React.FC = () => {
               />
             </div>
           )}
+          <div className={styles["notification-toggle"]}>
+            <span className={styles["toggle-label"]}>通知設定:</span>
+            <div className={styles["toggle-wrapper"]}>
+              <span className={styles["toggle-text"]}>オフ</span>
+              <label className={styles["switch"]}>
+                <input
+                  type="checkbox"
+                  checked={notificationEnabled} // ここでバックエンドから取得した状態が反映されます
+                  onChange={handleToggleChange}
+                />
+                <span className={styles["slider"]}></span>
+              </label>
+              <span className={styles["toggle-text"]}>オン</span>
+            </div>
+          </div>
           <Link to="/profile/edit" className={styles["edit-button"]}>
             編集
           </Link>


### PR DESCRIPTION
# メッセージ通知の設定オプションUIの実装 #52
# 概要
ユーザーが通知のON/OFFを設定できるUIを実装します。
 - 通知設定画面のデザイン
 - 通知設定の切り替え処理の実装
 - 通知設定の保存処理の実装

# 期待する動作
プロフィール画面のスライドボタンで通知切替ができる
オンの時は、新着表示されるが、オフの時は新着表示されない


# オンに設定
<img width="901" alt="スクリーンショット 2024-08-14 20 23 39" src="https://github.com/user-attachments/assets/eec1eb48-c92f-4ee4-9a6b-759f12c17e44">
<img width="905" alt="スクリーンショット 2024-08-14 20 23 55" src="https://github.com/user-attachments/assets/43d1078d-5654-493e-a5af-4203e6324679">


# オフに設定
<img width="904" alt="スクリーンショット 2024-08-14 20 24 04" src="https://github.com/user-attachments/assets/3acfa7a8-37f9-4079-b1d8-ce996106e2cf">
<img width="903" alt="スクリーンショット 2024-08-14 20 24 13" src="https://github.com/user-attachments/assets/b85ddeed-14e5-4fd5-a248-91579921e424">

Closes #52