### PR TITLE
ダイレクトメッセージ連続送信時の既読表示バグ修正

### DIFF
--- a/backend/app/controllers/direct_messages_controller.rb
+++ b/backend/app/controllers/direct_messages_controller.rb
@@ -161,6 +161,12 @@ class DirectMessagesController < ApplicationController
       status: "read",
       recipient_id: current_user.id
     })
+
+    # 全クライアントに既読情報をブロードキャスト
+    ActionCable.server.broadcast "direct_messages:#{message.sender_id}", {
+      direct_message: format_direct_message(message),
+      action: "update_read_status"
+    }
   end
 
   def message_read_by_recipient?(message)

--- a/frontend/app/src/hooks/useMessageStatusChannel.ts
+++ b/frontend/app/src/hooks/useMessageStatusChannel.ts
@@ -12,8 +12,15 @@ const useMessageStatusChannel = (
       { channel: "MessageStatusChannel", user_id: userId },
       {
         received: (data) => {
+          // データの内容を確認
           console.log(`Received data from MessageStatusChannel:`, data);
-          onUpdateStatus(data.message_id, data.status);
+
+          if (data.message_id && data.status) {
+            // 状態が "read" の場合に既読を更新
+            onUpdateStatus(data.message_id, data.status);
+          } else {
+            console.error("Invalid data received:", data);
+          }
         },
         connected() {
           console.log(`Connected to MessageStatusChannel for user ${userId}`);


### PR DESCRIPTION
## 概要
リアルでメッセージをやり取りしている際に連続送信したときにバグが発生している。一つ前の既読表示が未読になってしまう。3連続メッセージすると前２つが未読になり、最新が既読という症状である。

## 実装内容
メッセージ表示した際にリアルタイムで情報を送信し、表示させているデータに更新（マージ）するように変更

Closes #75