### PR TITLE
グループメッセージでのURLへのアクセス制限および制限表示追加

### DIFF
--- a/backend/app/controllers/groups_controller.rb
+++ b/backend/app/controllers/groups_controller.rb
@@ -1,6 +1,7 @@
 class GroupsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_group, only: [:show, :create_message, :update_message, :destroy_message, :clear_new_messages]
+  before_action :check_membership, only: [:show, :create_message, :update_message, :destroy_message, :clear_new_messages]
 
   def show
     messages = @group.messages.includes(:sender).map do |message|
@@ -167,6 +168,12 @@ class GroupsController < ApplicationController
     @group = Group.find_by(id: params[:group_id] || params[:id])
     unless @group
       render json: { error: "Group not found" }, status: :not_found
+    end
+  end
+
+  def check_membership
+    unless GroupMember.exists?(group_id: @group.id, user_id: current_user.id)
+      render json: { error: "このグループに参加していません。" }, status: :forbidden
     end
   end
 

--- a/frontend/app/src/styles/ChatStyles.css
+++ b/frontend/app/src/styles/ChatStyles.css
@@ -89,3 +89,16 @@
 .message button.delete:active {
   background-color: #bd2130;
 }
+
+/* 警告メッセージを目立たせるスタイル */
+.warning-message {
+  background-color: #ffcccc;
+  color: #cc0000;
+  font-weight: bold;
+  padding: 15px;
+  border-radius: 5px;
+  margin: 10px 0;
+  text-align: center;
+  border: 1px solid #cc0000;
+  font-size: 1.2rem;
+}


### PR DESCRIPTION
## 概要

グループメッセージでグループメンバーでなくてもURLを入力すると情報が表示されてしまう。

## 実装内容


グループメッセージでグループメンバーでなくてもURLを入力すると情報が表示されてしまうバグを修正。
グループメンバーかの判定を追加するし、メンバーでなければ警告文を表示しホーム画面戻す。

Closes #76
